### PR TITLE
Add Sentinel category and description

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ To contribute please raise a pull request
 * [Git Secrets](https://github.com/awslabs/git-secrets) This has both secrets and git in its name
 * [sshgit](https://github.com/eth0izzle/shhgit) if you like ones that look like obscenities 
 
+
+# Ones named after sci-fi defense systems or movies
+
+* [Sentinel](https://github.com/sentinel-cli/sentinel) Named after the robotic squids in the Matrix, just in case you wanted your code scanned by a machine sentinel.
+
 # Send your secrets to other people to be analysed
 
 * [ggshield](https://github.com/GitGuardian/ggshield) Named for everyones favourite secret leaking newspaper ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/GitGuardian/ggshield/Application%20Main%20Branch?style=for-the-badge)


### PR DESCRIPTION
Hi there!

This PR adds a new category for **Sentinel**, a statically compiled Git pre-commit secret scanner, matching the sarcastic theme of this list.

Thanks!