### PR TITLE
Rename Sentinel to Crenox

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To contribute please raise a pull request
 
 # Ones named after sci-fi defense systems or movies
 
-* [Sentinel](https://github.com/sentinel-cli/sentinel) Named after the robotic squids in the Matrix, just in case you wanted your code scanned by a machine sentinel.
+* [Crenox](https://github.com/crenoxhq/crenox) Because "Sentinel" sounded too much like a security product that blocks threats instead of just annoying you.
 
 # Send your secrets to other people to be analysed
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ To contribute please raise a pull request
 
 # Ones named after sci-fi defense systems or movies
 
-* [Crenox](https://github.com/crenoxhq/crenox) Because "Sentinel" sounded too much like a security product that blocks threats instead of just annoying you.
-Note: This project was formerly known as Sentinel.
+* [Crenox](https://github.com/crenoxhq/crenox) (Formerly Sentinel) Because "Sentinel" sounded too much like a security product that blocks threats instead of just annoying you.
+
 # Send your secrets to other people to be analysed
 
 * [ggshield](https://github.com/GitGuardian/ggshield) Named for everyones favourite secret leaking newspaper ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/GitGuardian/ggshield/Application%20Main%20Branch?style=for-the-badge)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To contribute please raise a pull request
 # Ones named after sci-fi defense systems or movies
 
 * [Crenox](https://github.com/crenoxhq/crenox) Because "Sentinel" sounded too much like a security product that blocks threats instead of just annoying you.
-
+Note: This project was formerly known as Sentinel.
 # Send your secrets to other people to be analysed
 
 * [ggshield](https://github.com/GitGuardian/ggshield) Named for everyones favourite secret leaking newspaper ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/GitGuardian/ggshield/Application%20Main%20Branch?style=for-the-badge)


### PR DESCRIPTION
Rebranding: The tool has been renamed from **Sentinel** to **Crenox**. This PR updates the repository link, name, and description.

New repo: https://github.com/crenoxhq/crenox